### PR TITLE
Add support for Python 3

### DIFF
--- a/src/wixpy/libmsiw.py
+++ b/src/wixpy/libmsiw.py
@@ -21,6 +21,18 @@ import os
 import _msi
 
 
+# Backwards compatibility for Python 2
+try:
+    long
+except NameError:
+    long = int
+
+try:
+    basestring
+except NameError:
+    basestring = (str,)
+
+
 class SummaryInfo(object):
     title = None
     author = None


### PR DESCRIPTION
Thank you for this great project, it just saved me a *ton* of time.

I'm using Python 3 for my project and made a few small tweaks to make it useful for everyone else. It's kind of a band-aid solution, another option could be to adopt `six.py`, or to remove any references to `long` and `basestring`.