### PR TITLE
Add support for "InstallDir"

### DIFF
--- a/src/wixpy/model.py
+++ b/src/wixpy/model.py
@@ -396,8 +396,12 @@ class WixPfDir(WixElement):
     is_dir = True
 
     def __init__(self, data):
-        pid = 'ProgramFiles64Folder' if data.get('Win64') == 'yes' \
+        pid = data.get("InstallDir") or (
+            'ProgramFiles64Folder'
+            if data.get('Win64') == 'yes'
             else 'ProgramFilesFolder'
+        )
+
         super(WixPfDir, self).__init__(Id=pid, Name='PFiles')
         self.add(WixInstallDir(data))
 


### PR DESCRIPTION
I noticed the install directory was [hard-coded to `ProgramFilesFolder`](https://github.com/sk1project/wixpy/blob/0026afa6aba2be57c0475e221862a71062deb530/src/wixpy/model.py#L399).

With this PR, users can install to a directory other than ProgramFilesFolder, such as `PersonalFolder`. It think it may even work with juts about any [Property](https://docs.microsoft.com/en-us/windows/win32/msi/property-reference), but I'm not well versed enough with MSI to know for sure.

**Example**

```json
{
    "Name": "My App",
    "UpgradeCode": "CFDD2143-B60A-4F5E-A81B-E1481DA674E1",
    "Version": "1.0.0",
    "Manufacturer": "Acme",
    "Description": "My Acme app",
    "InstallDir": "PersonalFolder",
    "...": "..."
}
```